### PR TITLE
Fix string parsing issue on travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Create a jasmine_selenium_runner.yml in spec/javascripts/support/ with the follo
       tags:
         - <%= ENV['TRAVIS_RUBY_VERSION'] || RUBY_VERSION %>
         - CI
-      tunnel_identifier: <%= ENV['TRAVIS_JOB_NUMBER'] ? "#{ENV['TRAVIS_JOB_NUMBER']}" : nil %>
+      tunnel_identifier: <%= ENV['TRAVIS_JOB_NUMBER'] ? "'#{ENV['TRAVIS_JOB_NUMBER']}'" : nil %>
       os: <%= ENV['SAUCE_OS'] %>
       browser_version: <%= ENV['SAUCE_BROWSER_VERSION'] %>
 


### PR DESCRIPTION
When running on travis the interpolation for the saucelabs tunnel identifier produces a float instead of a string, so `"46.1"` becomes `46.1` which makes Sauce Connect fail with `Invalid type received for 'tunnelIdentifier', got '48.3' of type '<type 'float'>' but Sauce OnDemand expects 'string'.`

I added single ticks around the value in the documentation section to fix this.