### PR TITLE
Correct the project's homepage

### DIFF
--- a/jasmine-selenium-runner.gemspec
+++ b/jasmine-selenium-runner.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['gvanhove@pivotal.io']
   spec.description   = %q{Run your jasmine tests in a real live browser!}
   spec.summary       = %q{Run your jasmine tests in a real live browser!}
-  spec.homepage         = "http://pivotal.github.com/jasmine/"
+  spec.homepage      = "https://github.com/jasmine/jasmine_selenium_runner"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Correct the projects home page so the link on https://rubygems.org/gems/jasmine_selenium_runner/ will go to the right place.